### PR TITLE
Kick button, bans, more admin functionality, fancier embed highlights

### DIFF
--- a/src/discord/admin_panel.py
+++ b/src/discord/admin_panel.py
@@ -188,5 +188,6 @@ class AdminEmbed(discord.ui.View):
             await interaction.response.defer()
         else:
             self.view_status = True
+            self.update_register_list()
             await self.update_message(self.data, interaction.guild, interaction)
             await interaction.response.defer()

--- a/src/discord/check_user.py
+++ b/src/discord/check_user.py
@@ -4,13 +4,23 @@ import data_management
 registered_list = []
 
 def user_embed(data_list, player_data, server):
-    role = discord.utils.get(server.roles, name="verified")
-    if role in player_data.roles:
-        verified_status = "User is verified"
-        user_clr = 0x00ff00
+    banned = discord.utils.get(server.roles, name="queue ban")
+    if banned in player_data.roles:
+        verified_status = "User is currently banned 😢"
+        user_clr = 0x000000
     else:
-        verified_status = "User is not verified"
-        user_clr = 0xFF0000
+        champion = discord.utils.get(server.roles, name="current champions")
+        if champion in player_data.roles:
+            verified_status = "User is a champion!"
+            user_clr = 0xFFD700
+        else:
+            role = discord.utils.get(server.roles, name="verified")
+            if role in player_data.roles:
+                verified_status = "User is verified"
+                user_clr = 0x00ff00
+            else:
+                verified_status = "User is not verified"
+                user_clr = 0xFF0000
     user_embed = discord.Embed(title=f'{player_data.global_name}', description=f'{verified_status}',
                                color=user_clr)
     user_embed.set_thumbnail(url=f'{player_data.avatar}')

--- a/src/discord/discord_client.py
+++ b/src/discord/discord_client.py
@@ -53,6 +53,5 @@ def run_discord_bot():
 
     bot.run(load_token())
 
-
 if __name__ == '__main__':
     run_discord_bot()

--- a/src/discord/inhouse_queue.py
+++ b/src/discord/inhouse_queue.py
@@ -3,6 +3,21 @@ import data_management
 import check_user
 from datetime import datetime
 
+
+class AdminKickPlayerModal(discord.ui.Modal, title='Kick User in Queue'):
+    player_name = discord.ui.TextInput(label='User\'s global name or username')
+
+    async def on_submit(self, interaction: discord.Interaction):
+        user_name = str(self.player_name)
+        await interaction.response.defer()
+
+class VoteKickPlayerModal(discord.ui.Modal, title='Votekick User in Queue'):
+    player_name = discord.ui.TextInput(label='User\'s global name or username')
+
+    async def on_submit(self, interaction: discord.Interaction):
+        user_name = str(self.player_name)
+        await interaction.response.defer()
+
 class InhouseQueue(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=None)
@@ -14,8 +29,14 @@ class InhouseQueue(discord.ui.View):
 
     def create_embed(self, data, server):
         if data:
-            embed_desc = "People currently in the inhouse queue"
-            embed_clr = 0x00ff00
+            champions = discord.utils.get(server.roles, name="current champions")
+            out = any(check in data for check in champions.members)
+            if out:
+                embed_desc = "A champion is in the queue!"
+                embed_clr = 0xFFD700
+            else:
+                embed_desc = "People currently in the inhouse queue"
+                embed_clr = 0x00ff00
         else:
             embed_desc = "Inhouse queue is currently empty"
             embed_clr = 0xFF0000
@@ -46,17 +67,21 @@ class InhouseQueue(discord.ui.View):
                        style=discord.ButtonStyle.green)
     async def join_queue(self, interaction: discord.Interaction, button: discord.ui.Button):
         server = interaction.user.guild
-        role = discord.utils.get(server.roles, name="verified")
-        if role in interaction.user.roles:
-            if interaction.user in self.data:
-                await interaction.response.send_message(content="You are already queued", ephemeral=True,
-                                                        delete_after=5)
-            else:
-                self.data.append(interaction.user)
-                await self.update_message(self.data, server)
-                await interaction.response.defer()
+        verify = discord.utils.get(server.roles, name="verified")
+        banned = discord.utils.get(server.roles, name="queue ban")
+        if banned in interaction.user.roles:
+            await interaction.response.send_message(content="You are currently banned from joining the queue", ephemeral=True, delete_after=5)
         else:
-            await interaction.response.send_message(content="You cannot join the queue", ephemeral=True, delete_after=5)
+            if verify in interaction.user.roles:
+                if interaction.user in self.data:
+                    await interaction.response.send_message(content="You are already queued", ephemeral=True,
+                                                            delete_after=5)
+                else:
+                    self.data.append(interaction.user)
+                    await self.update_message(self.data, server)
+                    await interaction.response.defer()
+            else:
+                await interaction.response.send_message(content="You cannot join the queue", ephemeral=True, delete_after=5)
 
     @discord.ui.button(label="Leave Queue", emoji="❌",
                        style=discord.ButtonStyle.red)
@@ -68,3 +93,15 @@ class InhouseQueue(discord.ui.View):
             await interaction.response.defer()
         else:
             await interaction.response.send_message(content="You aren't in the queue", ephemeral=True, delete_after=5)
+
+    @discord.ui.button(label="Kick User", emoji="🥾",
+                       style=discord.ButtonStyle.blurple)
+    async def kick_from_queue(self, interaction: discord.Interaction, button: discord.ui.Button):
+        server = interaction.user.guild
+        admin = discord.utils.get(server.roles, name="admin")
+        if admin in interaction.user.roles:
+            await interaction.response.send_modal(AdminKickPlayerModal())
+        elif len(self.data) == 10 and interaction.user in self.data:
+            await interaction.response.send_modal(VoteKickPlayerModal())
+        else:
+            await interaction.response.defer()

--- a/src/discord/register_user.py
+++ b/src/discord/register_user.py
@@ -1,6 +1,5 @@
 import discord
 import data_management
-import set_roles
 import check_user
 
 

--- a/src/discord/select_menus.py
+++ b/src/discord/select_menus.py
@@ -5,8 +5,9 @@ import data_management
 
 class EditUserModal(discord.ui.Modal, title='Edit Registered User'):
     player_name = discord.ui.TextInput(label='User\'s global name or Discord username')
-    set_mmr = discord.ui.TextInput(label='Set new MMR for user?', max_length=4, required=False)
-    remove_verify_role = discord.ui.TextInput(label='Remove verification from user?', max_length=1, required=False)
+    set_mmr = discord.ui.TextInput(label='Set new MMR for user?', max_length=5, required=False)
+    new_dotabuff = discord.ui.TextInput(label='Edit Dotabuff User URL?', required=False)
+    remove_verify = discord.ui.TextInput(label='Remove verification from user?', max_length=1, required=False)
     ban_user = discord.ui.TextInput(label='Ban user duration? (number = days banned)', max_length=2, required=False)
 
     async def on_submit(self, interaction: discord.Interaction):
@@ -18,8 +19,28 @@ class EditUserModal(discord.ui.Modal, title='Edit Registered User'):
             if new_mmr != "":
                 try:
                     int_new_mmr = int(new_mmr)
+                    data_management.update_user_data(check_if_exists[1].id, [2], int_new_mmr)
                 except ValueError:
-                    await interaction.response.send_message('Please only input numbers for inhouse bans',
+                    await interaction.response.send_message('Please only input numbers for mmr',
+                                                            ephemeral=True,
+                                                            delete_after=10)
+            steam_id = str(self.new_dotabuff)
+            if steam_id != "":
+                try:
+                    steam_id = steam_id.split("players/")
+                    steam_id = steam_id[1].split('/')
+                    int_steam_id = int(steam_id[0])
+                    data_management.update_user_data(check_if_exists[1].id, [1], int_steam_id)
+                except ValueError:
+                    await interaction.response.send_message('Please enter a full Dotabuff URL when updating a user',
+                                                            ephemeral=True,
+                                                            delete_after=10)
+            verify_role = str(self.remove_verify)
+            if verify_role != "":
+                    if verify_role.lower() == "y":
+                        pass
+                    else:
+                        await interaction.response.send_message('Please enter a full Dotabuff URL when updating a user',
                                                             ephemeral=True,
                                                             delete_after=10)
             ban_time = str(self.ban_user)
@@ -70,6 +91,7 @@ class UserOptions(discord.ui.View):
 
     @discord.ui.select(placeholder="Select an action here", min_values=1, max_values=1, options=[
         discord.SelectOption(label="Search", emoji="🔎", description="Search for a specific user with their name"),
+        discord.SelectOption(label="Update", emoji="❗", description="Notify admins of MMR change (NOT WORKING YET)"),
         discord.SelectOption(label="Ladder", emoji="🪜", description="View player leaderboards (NOT WORKING YET)"),
         discord.SelectOption(label="Refresh", emoji="♻", description="Select to allow you to refresh options")
     ]
@@ -78,6 +100,9 @@ class UserOptions(discord.ui.View):
         match select.values[0]:
             case "Search":
                 await interaction.response.send_modal(ViewUserModal())
+            case "Update":
+                await interaction.response.send_message(content="This feature has not yet been added", ephemeral=True,
+                                                        delete_after=10)
             case "Ladder":
                 await interaction.response.send_message(content="This feature has not yet been added", ephemeral=True,
                                                         delete_after=10)


### PR DESCRIPTION
There is now a kick button for the queue (although this does not have full functionality yet). In addition a ban role has been added and can now be added to a user via the admin menu. This menu also allows for editing MMR, Dotabuff ID, and removing verification. The remove user option has been improved and the modal can remove roles, however it doesn't delete a user's data from the CSV yet.

I've also increased the number of colours which show in a player view or the queue. banned players have a black embed colour, whilst those with the "current champions" role get a gold highlight. Champions also get a custom message when viewed or when joining the queue, for increased bragging rights.