### PR TITLE
initialisation + unverified list hotfixes

### DIFF
--- a/data/default_config.yml
+++ b/data/default_config.yml
@@ -4,10 +4,12 @@ CHANNELS:
   queue_channel: "inhouse-queue"
   notification_channel: "inhouse-notifications"
   chat_channel: "inhouse-chat"
-
 ROLES:
   admin_role: "admin"
   registered_role: "inhouse"
   verified_role: "verified"
   banned_role: "queue ban"
   champions_role: "current champions"
+CONFIG:
+  server_id: None
+  setup_complete: 'No'

--- a/src/discord/check_user.py
+++ b/src/discord/check_user.py
@@ -106,7 +106,7 @@ def user_list(list_condition, user=None):
         case "Add":
             register_list.append(user)
         case "Remove":
-            register_list.registered_list.remove(user)
+            register_list.remove(user)
         case _:
             pass
     return register_list

--- a/src/discord/check_user.py
+++ b/src/discord/check_user.py
@@ -1,6 +1,7 @@
 import discord
 import data_management
 
+register_list = []
 
 def user_embed(data_list, player_data, server):
     roles_id = data_management.load_config_data(server, 'ROLES')
@@ -100,16 +101,12 @@ def check_role_priority(user):
 
 
 def user_list(list_condition, user=None):
+    global register_list
     match list_condition:
         case "Add":
-            UnverifiedUserList().registered_list.append(user)
+            register_list.append(user)
         case "Remove":
-            UnverifiedUserList().registered_list.remove(user)
+            register_list.registered_list.remove(user)
         case _:
             pass
-    return UnverifiedUserList().registered_list
-
-
-class UnverifiedUserList:
-    def __init__(self):
-        self.registered_list = []
+    return register_list

--- a/src/discord/data_management.py
+++ b/src/discord/data_management.py
@@ -23,9 +23,10 @@ def load_config_data(server, category, sub_category=None):
         data = yaml.load(f, Loader=SafeLoader)
     if sub_category is None:
         return data[category]
-    else:
+    elif data[[category][sub_category]]:
         return data[category][sub_category]
-
+    else:
+        return None
 
 def update_config(server, category, sub_category, new_value):
     with open(f'../../data/{server.id}_config.yml') as f:

--- a/src/discord/data_management.py
+++ b/src/discord/data_management.py
@@ -23,7 +23,7 @@ def load_config_data(server, category, sub_category=None):
         data = yaml.load(f, Loader=SafeLoader)
     if sub_category is None:
         return data[category]
-    elif data[[category][sub_category]]:
+    elif data[category][sub_category]:
         return data[category][sub_category]
     else:
         return None

--- a/src/discord/discord_client.py
+++ b/src/discord/discord_client.py
@@ -16,9 +16,10 @@ def run_discord_bot():
     async def on_ready():
         print('bot now running!')
         for server in bot.guilds:
-            check_config = data_management.load_config_data(server, 'CONFIG', 'setup_complete')
-            if check_config == 'Yes':
-                await initialisation.run_user_modules(server)
+            if isfile(f'../../data/{server.id}_config.yml'):
+                check_config = data_management.load_config_data(server, 'CONFIG', 'setup_complete')
+                if check_config == 'Yes':
+                    await initialisation.run_user_modules(server)
 
     @bot.command()
     @commands.is_owner()

--- a/src/discord/discord_client.py
+++ b/src/discord/discord_client.py
@@ -16,10 +16,11 @@ def run_discord_bot():
     async def on_ready():
         print('bot now running!')
         for server in bot.guilds:
-            if isfile(f'../../data/{server.id}_config.yml'):
-                check_config = data_management.load_config_data(server, 'CONFIG', 'setup_complete')
-                if check_config == 'Yes':
-                    await initialisation.run_user_modules(server)
+            check_config = data_management.load_config_data(server, 'CONFIG', 'setup_complete')
+            if not check_config:
+                print(f'No config file found for {server}')
+            elif check_config == 'Yes':
+                await initialisation.run_user_modules(server)
 
     @bot.command()
     @commands.is_owner()


### PR DESCRIPTION
A few small hotfixes for when the bot loads up and the unverified players list. Before there was an error if the bot tried to load a nonexistent config which was obviously a problem when loading the bot onto a new server. In addition to this, my attempt at changing the global variable to a class for registered players didn't work as planned. I've reverted it for the time being.